### PR TITLE
Update `require()` path for `assert` module

### DIFF
--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert').strict,
+const assert = require('assert/strict'),
   lib = require('./../src/lib.js');
 
 


### PR DESCRIPTION
With Node v16 - the `require()` path for the strict stdlib `assert` lib has changed/improved.