### PR TITLE
`eslint` tweak / `README.md` update

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,9 +27,8 @@
       "error",
       "single"
     ],
-    "semi-spacing": [
-      "error"
-    ]
+    "semi-spacing": "error",
+    "spaced-comment": "error"
   },
   "ignorePatterns": [
     "/dist/"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ jobs:
 
       # -- further job steps --
 
-      - name: Slack message
+      - name: Slack message failure
         if: (cancelled() || failure()) && (github.ref == 'refs/heads/main')
         uses: flipgroup/action-slack@main
         with:


### PR DESCRIPTION
Two very small QOL items:

- Added the [`spaced-comment`](https://eslint.org/docs/latest/rules/spaced-comment) rule to `eslint` - no code invalidated this, but nice to have.
- Tweaked `README.md` usage example for the "workflow failed only" messaging implement.
 