### PR TITLE
GitHub Actions bump Node.js `v24`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # @v6.0.3
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # @v6.4.0
         with:
           cache: npm
           node-version: 20.x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # @v6.4.0
         with:
           cache: npm
-          node-version: 20.x
+          node-version: 24.x
       - name: Install npm packages
         run: npm ci
       - name: Lint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
-  "javascript.format.enable": true,
-  "javascript.format.insertSpaceAfterCommaDelimiter": false,
-  "javascript.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
-  "javascript.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
-  "javascript.format.semicolons": "insert",
-  "javascript.preferences.quoteStyle": "single",
+  "js/ts.format.enabled": true,
+  "js/ts.format.insertSpaceAfterCommaDelimiter": false,
+  "js/ts.format.insertSpaceAfterFunctionKeywordForAnonymousFunctions": false,
+  "js/ts.format.insertSpaceAfterOpeningAndBeforeClosingEmptyBraces": false,
+  "js/ts.format.semicolons": "insert",
+  "js/ts.preferences.quoteStyle": "single",
   "json.format.enable": true,
   "json.format.keepLines": true,
   "[javascript][json][jsonc]": {

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Flip Group
+Copyright (c) 2026 Flip Group
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Multiple job workflow:
 jobs:
   slack-message-start:
     name: Slack message start
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Slack message
         uses: flipgroup/action-slack@main
@@ -67,7 +67,7 @@ jobs:
       - slack-message-start
       - first
       - second
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Slack message
         uses: flipgroup/action-slack@main
@@ -88,10 +88,7 @@ jobs:
     name: Job cancelled or failure
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      # -- further job steps --
+      # -- insert job steps --
 
       - name: Slack message failure
         if: (cancelled() || failure()) && (github.ref == 'refs/heads/main')

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Slack workflow start/finish messaging
 
 inputs:
   channel:
-    description: Name or ID of the target Slack channel.
+    description: Name or ID of target Slack channel.
     required: true
   field-list:
     description: |
@@ -25,4 +25,4 @@ inputs:
 
 runs:
   main: ./dist/main.js
-  using: node20
+  using: node24


### PR DESCRIPTION
Applies the following GitHub Action workflow changes:

- Implement the use of GitHub Actions compatible with Node.js `v24`.
- Swap out the use of version tags for external actions to full SHA-1 commits to defeat action tainting / supply chain attacks.
- Update action execution environment to Node.js `v24`.
- Refactor `README.md` examples.
